### PR TITLE
Fix the inverted origin in dataloaders

### DIFF
--- a/examples/python/datasets/icl.py
+++ b/examples/python/datasets/icl.py
@@ -83,7 +83,8 @@ class ICLDataset:
 
         rgb_id = self.rgb_list[idx][0]
         depth_id = self.depth_list[idx][0]
-        T = np.linalg.inv(self.gt_poses[idx])
+        pose = self.gt_poses[idx]
+        pose_inv = np.linalg.inv(pose)
 
         bgr = cv.imread(os.path.join(self.data_source, rgb_id))
         rgb = cv.cvtColor(bgr, cv.COLOR_BGR2RGB)
@@ -101,15 +102,15 @@ class ICLDataset:
         )
 
         pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
-            rgbd, intrinsic, T, project_valid_depth_only=True
+            rgbd, intrinsic, pose_inv, project_valid_depth_only=True
         )
 
         xyz = np.array(pcd.points)
         colors = np.array(pcd.colors)
 
         if self.get_color:
-            return xyz, colors, np.array(T)
-        return xyz, np.array(T)
+            return xyz, colors, np.array(pose)
+        return xyz, np.array(pose)
 
     def __len__(self):
         return len(self.rgb_list)

--- a/examples/python/datasets/scannet.py
+++ b/examples/python/datasets/scannet.py
@@ -30,7 +30,7 @@ class ScanNet:
     def __getitem__(self, idx):
 
         pose = np.loadtxt(os.path.join(self.data_source, "pose", self.pose_list[idx]))
-        pose = np.linalg.inv(pose)
+        pose_inv = np.linalg.inv(pose)
 
         bgr = cv.imread(os.path.join(self.data_source, "color", self.rgb_list[idx]))
         rgb = cv.cvtColor(bgr, cv.COLOR_BGR2RGB)
@@ -59,7 +59,7 @@ class ScanNet:
         )
 
         pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
-            rgbd, intrinsic, pose, project_valid_depth_only=True
+            rgbd, intrinsic, pose_inv, project_valid_depth_only=True
         )
 
         xyz = np.array(pcd.points)

--- a/examples/python/datasets/tum.py
+++ b/examples/python/datasets/tum.py
@@ -140,8 +140,8 @@ class TUMDataset:
         rgb_id, depth_id = self.matches[idx]
 
         pose_timestamp = self.find_closest_ts(depth_id)
-        T = self.conver_to_homo(self.gt_list[pose_timestamp])
-        T = np.linalg.inv(T)
+        pose = self.conver_to_homo(self.gt_list[pose_timestamp])
+        pose_inv = np.linalg.inv(pose)
 
         bgr = cv.imread(os.path.join(self.data_source, "rgb", "{:.6f}".format(rgb_id) + ".png"))
         rgb = cv.cvtColor(bgr, cv.COLOR_BGR2RGB)
@@ -163,15 +163,15 @@ class TUMDataset:
         )
 
         pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
-            rgbd, intrinsic, T, project_valid_depth_only=True
+            rgbd, intrinsic, pose_inv, project_valid_depth_only=True
         )
 
         xyz = np.array(pcd.points)
         colors = np.array(pcd.colors)
 
         if self.get_color:
-            return xyz, colors, np.array(T)
-        return xyz, np.array(T)
+            return xyz, colors, np.array(pose)
+        return xyz, np.array(pose)
 
     def __len__(self):
         return len(self.matches)

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,6 +1,6 @@
 open3d
 natsort
-tqdm=
+tqdm
 pandas
 diskcache
 vdbfusion


### PR DESCRIPTION
As describe in #2, the global pose was inverted to conform to the `open3d` convention, which assumes a transformation from world to camera. This however leads to the wrong origin position. This pull request fixed this problem at three RGBD image based examples.