### PR TITLE
CMake: Change boost URL to fix faulty sha256 hash

### DIFF
--- a/3rdparty/boost/boost.cmake
+++ b/3rdparty/boost/boost.cmake
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2")
+set(BOOST_URL "https://archives.boost.io/release/1.71.0/source/boost_1_71_0.tar.bz2")
 set(BOOST_URL_SHA256 "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee")
 set(BOOST_CONFIGURE <SOURCE_DIR>/bootstrap.sh --with-libraries=iostreams,regex)
 set(BOOST_INSTALL


### PR DESCRIPTION
Currently, Boost 1.71 is downloaded via `https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2`, which results in a faulty sha256 hash.
Changing it to the currently official `https://archives.boost.io/release/1.71.0/source/boost_1_71_0.tar.bz2` archive url fixes this issue and downloads the correct package with a successful hash validation